### PR TITLE
进一步完善了macOS的支持与体验

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -130,7 +130,6 @@ public partial class Main : Control
 
 			if (os_name == "macOS")
 			{
-				window.ExtendToTitle = true;
 				window.Unresizable = true;
 				nodeBtnInfo.Position += new Vector2(0, 20);
 				nodeComboLanguage.Position += new Vector2(0, 20);

--- a/Main.cs
+++ b/Main.cs
@@ -134,11 +134,14 @@ public partial class Main : Control
 				nodeBtnInfo.Position += new Vector2(0, 20);
 				nodeComboLanguage.Position += new Vector2(0, 20);
 				nodeTitleBar.Visible = true;
-#if DEBUG
-				nodeTitleBar.Color = new Color(1.0f, 0.0f, 0.0f, 1.0f);
-#else
-				nodeTitleBar.Color = new Color(0.0f, 0.0f, 0.0f, 0.0f);
-#endif
+				if (OS.IsDebugBuild())
+				{
+					nodeTitleBar.Color = new Color(1.0f, 0.0f, 0.0f, 1.0f);
+				}
+				else
+				{
+					nodeTitleBar.Color = new Color(0.0f, 0.0f, 0.0f, 0.0f);
+				}
 			}
 
 			windowScale = (int)Mathf.Floor((screenSize.Size.Y - screenSize.Position.Y) / windowDesignSize.Y);

--- a/Main.cs
+++ b/Main.cs
@@ -153,7 +153,7 @@ public partial class Main : Control
 			{
 				windowScale = 1;
 			}
-			
+
 			//Tooltip与下拉菜单大小
 			var theme = Theme;
 			theme.SetFontSize("font_size", "PopupMenu", FontSize(theme.GetFontSize("font_size", "PopupMenu"), windowScale));
@@ -652,15 +652,15 @@ public partial class Main : Control
 	public void _on_title_bar_gui_input(InputEvent @event)
 	{
 		if (@event is InputEventMouseButton mouseButton)
-	{
-		if (mouseButton.ButtonIndex == MouseButton.Left)
 		{
-			if (mouseButton.Pressed)
+			if (mouseButton.ButtonIndex == MouseButton.Left)
 			{
-				DisplayServer.WindowStartDrag();
+				if (mouseButton.Pressed)
+				{
+					DisplayServer.WindowStartDrag();
+				}
 			}
 		}
-	}
 	}
 
 	public string PathTrim(string originalPath)

--- a/Main.cs
+++ b/Main.cs
@@ -131,6 +131,7 @@ public partial class Main : Control
 			if (os_name == "macOS")
 			{
 				window.ExtendToTitle = true;
+				window.Unresizable = true;
 				nodeBtnInfo.Position += new Vector2(0, 20);
 				nodeComboLanguage.Position += new Vector2(0, 20);
 				nodeTitleBar.Visible = true;

--- a/Main.cs
+++ b/Main.cs
@@ -12,6 +12,9 @@ using System.Threading.Tasks;
 public partial class Main : Control
 {
 	[Export]
+	ColorRect nodeTitleBar = null!;
+
+	[Export]
 	AnimationPlayer nodeBgAnim = null!;
 	[Export]
 	Button nodeBtnInfo = null!;
@@ -125,6 +128,19 @@ public partial class Main : Control
 			var screenSize = DisplayServer.ScreenGetUsableRect(screenId);
 			var windowDesignSize = new Vector2(640, 480) * 1.5f;
 
+			if (os_name == "macOS")
+			{
+				window.ExtendToTitle = true;
+				nodeBtnInfo.Position += new Vector2(0, 20);
+				nodeComboLanguage.Position += new Vector2(0, 20);
+				nodeTitleBar.Visible = true;
+#if DEBUG
+				nodeTitleBar.Color = new Color(1.0f, 0.0f, 0.0f, 1.0f);
+#else
+				nodeTitleBar.Color = new Color(0.0f, 0.0f, 0.0f, 0.0f);
+#endif
+			}
+
 			windowScale = (int)Mathf.Floor((screenSize.Size.Y - screenSize.Position.Y) / windowDesignSize.Y);
 			if (windowScale > 1)
 			{
@@ -137,6 +153,7 @@ public partial class Main : Control
 			{
 				windowScale = 1;
 			}
+			
 			//Tooltip与下拉菜单大小
 			var theme = Theme;
 			theme.SetFontSize("font_size", "PopupMenu", FontSize(theme.GetFontSize("font_size", "PopupMenu"), windowScale));
@@ -410,29 +427,9 @@ public partial class Main : Control
 		nodeBtnUnpatch.Disabled = true;
 		nodeEditGamePath.Editable = false;
 		nodeBtnBrowse.Disabled = true;
-		var path = nodeEditGamePath.Text.TrimPrefix("\"").TrimSuffix("\"").TrimPrefix("\'").TrimSuffix("\'").TrimSuffix("/").TrimSuffix("\\");
-		if (os_name != "Windows" && path.StartsWith("~/"))
-		{
-			GD.Print("Non-Windows Home Directory Processing");
-			string homePath = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
-			path = homePath + path.Substring(1);
-		}
-		if (os_name == "macOS")
-		{
-			if (path.EndsWith("/DELTARUNE"))
-			{
-				path += "/DELTARUNE.app/Contents/Resources";
-			}
-			else if (path.EndsWith(".app"))
-			{
-				path += "/Contents/Resources";
-			}
-			else if (path.EndsWith("/Contents"))
-			{
-				path += "/Resources";
-			}
-		}
-		GD.Print($"Final game path: {path}");
+
+		var path = PathTrim(nodeEditGamePath.Text);
+
 		nodeEditGamePath.Text = path;
 		bool found = FileAccess.FileExists(path + "/" + dataname + ".bak") || DirAccess.DirExistsAbsolute(path + "/backup");
 		foreach (var chapter in chapters)
@@ -652,6 +649,49 @@ public partial class Main : Control
 		}
 	}
 
+	public void _on_title_bar_gui_input(InputEvent @event)
+	{
+		if (@event is InputEventMouseButton mouseButton)
+	{
+		if (mouseButton.ButtonIndex == MouseButton.Left)
+		{
+			if (mouseButton.Pressed)
+			{
+				DisplayServer.WindowStartDrag();
+			}
+		}
+	}
+	}
+
+	public string PathTrim(string originalPath)
+	{
+		var finalPath = originalPath.TrimPrefix("\"").TrimSuffix("\"").TrimPrefix("\'").TrimSuffix("\'").TrimSuffix("/").TrimSuffix("\\");
+
+		if (os_name != "Windows" && finalPath.StartsWith("~/"))
+		{
+			GD.Print("Non-Windows Home Directory Processing");
+			string homePath = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+			finalPath = homePath + finalPath.Substring(1);
+		}
+		if (os_name == "macOS")
+		{
+			if (finalPath.EndsWith("/DELTARUNE"))
+			{
+				finalPath += "/DELTARUNE.app/Contents/Resources";
+			}
+			else if (finalPath.EndsWith(".app"))
+			{
+				finalPath += "/Contents/Resources";
+			}
+			else if (finalPath.EndsWith("/Contents"))
+			{
+				finalPath += "/Resources";
+			}
+		}
+
+		GD.Print($"Final game path: {finalPath}");
+		return finalPath;
+	}
 	public async void Patch(bool use_backup = true)
 	{
 		starttime = DateTime.Now;
@@ -1004,7 +1044,8 @@ public partial class Main : Control
 	}
 	public void _on_unpatch_pressed()
 	{
-		var path = nodeEditGamePath.Text.TrimPrefix("\"").TrimSuffix("\"").TrimPrefix("\'").TrimSuffix("\'").TrimSuffix("/").TrimSuffix("\\");
+		var path = PathTrim(nodeEditGamePath.Text);
+
 		if (!DirAccess.DirExistsAbsolute(path + "/backup"))
 		{
 			nodeWindowPopupContent.Text = "locNoBakDetected";

--- a/Main.tscn
+++ b/Main.tscn
@@ -46,7 +46,7 @@ _data = {
 &"bg_anim": SubResource("Animation_cm0pq")
 }
 
-[node name="Main" type="Control" node_paths=PackedStringArray("nodeBgAnim", "nodeBtnInfo", "nodeComboLanguage", "nodeTextPatcherVersion", "nodeBtnUpdatePatcher", "nodeTextPatchVersion", "nodeUpdatePatchRow", "nodeBtnUpdatePatch", "nodeProgress", "nodeEditGamePath", "nodeBtnBrowse", "nodeBtnPatch", "nodeBtnUnpatch", "nodeOpenDialog", "nodeWindowReadme", "nodeWindowReadmeContent", "nodeWindowLog", "nodeWindowLogContent", "nodeWindowPopup", "nodeWindowPopupContent", "nodeWindowPatch", "nodeWindowPatchContent")]
+[node name="Main" type="Control" node_paths=PackedStringArray("nodeTitleBar", "nodeBgAnim", "nodeBtnInfo", "nodeComboLanguage", "nodeTextPatcherVersion", "nodeBtnUpdatePatcher", "nodeTextPatchVersion", "nodeUpdatePatchRow", "nodeBtnUpdatePatch", "nodeProgress", "nodeEditGamePath", "nodeBtnBrowse", "nodeBtnPatch", "nodeBtnUnpatch", "nodeOpenDialog", "nodeWindowReadme", "nodeWindowReadmeContent", "nodeWindowLog", "nodeWindowLogContent", "nodeWindowPopup", "nodeWindowPopupContent", "nodeWindowPatch", "nodeWindowPatchContent")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -55,6 +55,7 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_glv2v")
 script = ExtResource("2_uu6xs")
+nodeTitleBar = NodePath("TitleBar")
 nodeBgAnim = NodePath("Background/AnimationPlayer")
 nodeBtnInfo = NodePath("BtnInfo")
 nodeComboLanguage = NodePath("ComboLanguage")
@@ -265,6 +266,13 @@ popup/item_1/id = 1
 popup/item_2/text = "中文（繁體）"
 popup/item_2/id = 2
 
+[node name="TitleBar" type="ColorRect" parent="."]
+visible = false
+layout_mode = 0
+offset_right = 640.0
+offset_bottom = 20.0
+color = Color(1, 0, 0, 0)
+
 [node name="FileDialog" type="FileDialog" parent="."]
 title = "Open a Directory"
 ok_button_text = "Select Current Folder"
@@ -387,6 +395,7 @@ autowrap_mode = 3
 [connection signal="pressed" from="BottomContainer/Update" to="." method="_on_update_pressed"]
 [connection signal="pressed" from="BtnInfo" to="." method="_on_info_pressed"]
 [connection signal="item_selected" from="ComboLanguage" to="." method="_on_language_item_selected"]
+[connection signal="gui_input" from="TitleBar" to="." method="_on_title_bar_gui_input"]
 [connection signal="dir_selected" from="FileDialog" to="." method="_on_file_dialog_dir_selected"]
 [connection signal="close_requested" from="Log" to="." method="_on_window_close_requested"]
 [connection signal="close_requested" from="Popup" to="." method="_on_popup_close_requested"]

--- a/project.godot
+++ b/project.godot
@@ -30,6 +30,7 @@ config/size/resizable=true
 window/size/viewport_width=640
 window/size/viewport_height=480
 window/size/resizable=false
+window/size/extend_to_title=true
 window/subwindows/embed_subwindows=false
 window/stretch/mode="viewport"
 window/stretch/scale_mode="integer"


### PR DESCRIPTION
## 改进：
- 单独剥离路径优化为`PathTrim`，顺便解决了在无意间发现的卸载补丁无法进行路径补充与主目录替换的问题
- 在macOS下启用`ExtendToTitle`（按照Godot文档也只有macOS支持，Godot编辑器也在macOS下启用了它），并且创建了一个理论上在其他系统不可见的`TitleBar`用来拖动窗口（在DEBUG下显示为红色，RELEASE下透明来区分）
    - 此调整可能会让部分UI组件稍显拥挤，但总体在可接受范围内，如有需要，可以让下面的组件下移20像素（TitleBar高20像素）

## 部分效果：
DEBUG下：
<img width="1920" height="746" alt="image" src="https://github.com/user-attachments/assets/0c94333a-275d-49a7-845c-e16542cb258b" />
RELEASE下：
<img width="1920" height="752" alt="image" src="https://github.com/user-attachments/assets/5cfdb382-417e-45b7-84d2-22f91ee6cc6d" />

